### PR TITLE
Rebuild with hdf5 1.10.4

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -8,8 +8,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 pin_run_as_build:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -8,8 +8,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 pin_run_as_build:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -8,8 +8,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 pin_run_as_build:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 macos_machine:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 macos_machine:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
-hdf5:
-- 1.10.5
 libnetcdf:
 - 4.6.2
 macos_machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 38f20237193fc74473cbd9259f2921f945a8da836f76616c70451e55edffa656
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   entry_points:
     - planar_hex = mpas_tools.planar_hex:main
@@ -24,7 +24,7 @@ requirements:
     - cmake
   host:
     - python
-    - hdf5
+    - hdf5 1.10.4
     - libnetcdf
     - setuptools
     - pip
@@ -33,7 +33,7 @@ requirements:
   run:
     - python
     - netcdf4
-    - hdf5
+    - hdf5 1.10.4
     - libnetcdf
     - numpy
     - scipy


### PR DESCRIPTION
Needed for compatibility with CDAT, which has not yet been built with hdf5 1.10.5

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
