### PR TITLE
Build with libnetcdf 4.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2fd0681d1cc7ed2fcabdbf4602f70c0f8fb31bda6d804dffe1d48ec6cc48cf06
 
 build:
-  number: 0
+  number: 100
   skip: true  # [win]
   entry_points:
     - planar_hex = mpas_tools.planar_hex:main
@@ -25,7 +25,7 @@ requirements:
   host:
     - python
     - hdf5
-    - libnetcdf
+    - libnetcdf 4.6.2
     - setuptools
     - pip
     - netcdf4
@@ -34,7 +34,7 @@ requirements:
     - python
     - netcdf4
     - hdf5
-    - libnetcdf
+    - libnetcdf 4.6.2
     - numpy
     - scipy
     - xarray


### PR DESCRIPTION
Build number is 100 to no clash with builds with libnetcdf 4.7.1

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
